### PR TITLE
Feature: 코드 리팩토링(#71)

### DIFF
--- a/backend/src/main/java/aimo/backend/domains/comment/service/ParentCommentMemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/comment/service/ParentCommentMemberService.java
@@ -2,6 +2,8 @@ package aimo.backend.domains.comment.service;
 
 import static aimo.backend.common.exception.ErrorCode.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/backend/src/main/java/aimo/backend/domains/like/controller/LikeController.java
+++ b/backend/src/main/java/aimo/backend/domains/like/controller/LikeController.java
@@ -71,6 +71,7 @@ public class LikeController {
 
 		parentCommentLikeMemberService.likeParentComment(parameter);
 
-		return ResponseEntity.ok(DataResponse.ok());
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(DataResponse.created());
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/like/controller/LikeController.java
+++ b/backend/src/main/java/aimo/backend/domains/like/controller/LikeController.java
@@ -46,23 +46,29 @@ public class LikeController {
 	@PostMapping("/comments/child/{childCommentId}/likes")
 	public ResponseEntity<DataResponse<Void>> likeChildComment(
 		@PathVariable Long childCommentId,
-		@RequestParam("likeType") LikeType likeType) {
+		@RequestParam("likeType") LikeType likeType
+	) {
 		Long memberId = MemberLoader.getMemberId();
+
 		LikeChildCommentParameter parameter =
 			LikeChildCommentParameter.of(memberId, childCommentId, likeType);
+
 		childCommentLikeMemberService.likeChildComment(parameter);
-		return ResponseEntity
-			.status(HttpStatus.CREATED)
+
+		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(DataResponse.created());
 	}
 
 	@PostMapping("/comments/{parentCommentId}/likes")
 	public ResponseEntity<DataResponse<Void>> likeParentComment(
 		@PathVariable Long parentCommentId,
-		@RequestParam("likeType") LikeType likeType) {
+		@RequestParam("likeType") LikeType likeType
+	) {
 		Long memberId = MemberLoader.getMemberId();
+
 		LikeParentCommentParameter parameter =
 			LikeParentCommentParameter.of(memberId, parentCommentId, likeType);
+
 		parentCommentLikeMemberService.likeParentComment(parameter);
 
 		return ResponseEntity.ok(DataResponse.ok());

--- a/backend/src/main/java/aimo/backend/domains/like/service/ChildCommentLikeMemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/like/service/ChildCommentLikeMemberService.java
@@ -29,6 +29,7 @@ public class ChildCommentLikeMemberService {
 	public void likeChildComment(LikeChildCommentParameter parameter) {
 		Long childCommentId = parameter.childCommentId();
 		Long memberId = parameter.memberId();
+
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> ApiException.from(MEMBER_NOT_FOUND));
 
@@ -36,6 +37,7 @@ public class ChildCommentLikeMemberService {
 
 		if (parameter.likeType() == LikeType.LIKE) {
 			if (childCommentLikeRepository.existsByChildCommentIdAndMemberId(childCommentId, memberId)) return;
+
 			childCommentLikeRepository.save(ChildCommentLike.from(member, childComment));
 			return;
 		}

--- a/backend/src/main/java/aimo/backend/domains/like/service/ParentCommentLikeMemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/like/service/ParentCommentLikeMemberService.java
@@ -30,6 +30,7 @@ public class ParentCommentLikeMemberService {
 		Long memberId = parameter.memberId();
 		Long parentCommentId = parameter.parentCommentId();
 		LikeType likeType = parameter.likeType();
+
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> ApiException.from(MEMBER_NOT_FOUND));
 
@@ -38,6 +39,7 @@ public class ParentCommentLikeMemberService {
 		if (likeType == LikeType.LIKE) {
 			// 라이크가 이미 존재하면 무시
 			if (parentCommentLikeRepository.existsByParentCommentIdAndMemberId(parentCommentId, memberId)) return;
+
 			parentCommentLikeRepository.save(ParentCommentLike.from(member, parentComment));
 			return;
 		}

--- a/backend/src/main/java/aimo/backend/domains/like/service/PostLikeMemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/like/service/PostLikeMemberService.java
@@ -29,12 +29,13 @@ public class PostLikeMemberService {
 	public void likePost(LikePostParameter parameter) {
 		Long postId = parameter.postId(), memberId = parameter.memberId();
 		LikeType likeType = parameter.likeType();
+
 		Post post = postService.findById(postId);
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> ApiException.from(MEMBER_NOT_FOUND));
 
 		if (likeType == LikeType.LIKE) {
-			// 라이크가 이미 존재하면 무시
+			// 라이크가 존재하면 중복 등록 방지
 			if (postLikeRepository.existsByPostIdAndMemberId(postId, memberId))
 				return;
 
@@ -43,6 +44,7 @@ public class PostLikeMemberService {
 			return ;
 		}
 
+		// 라이크가 이미 존재하면 삭제
 		postLikeRepository.deleteByMember_IdAndPost_Id(member.getId(), postId);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/controller/MemberController.java
+++ b/backend/src/main/java/aimo/backend/domains/member/controller/MemberController.java
@@ -55,53 +55,71 @@ public class MemberController {
 
 	@PostMapping("/logout")
 	public ResponseEntity<DataResponse<Void>> logoutMember(HttpServletRequest request) {
-		String accessToken = jwtTokenProvider.extractAccessToken(request).orElse(null);
+		String accessToken = jwtTokenProvider.extractAccessToken(request)
+			.orElse(null);
+
 		memberService.logoutMember(new LogoutRequest(accessToken));
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@PostMapping("/signup")
 	public ResponseEntity<DataResponse<Void>> signupMember(@RequestBody @Valid SignUpParameter parameter) {
 		memberService.signUp(parameter);
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@PostMapping
-	public ResponseEntity<DataResponse<Void>> deleteMember(@RequestBody DeleteMemberRequest deleteMemberRequest) {
+	public ResponseEntity<DataResponse<Void>> deleteMember(@RequestBody @Valid DeleteMemberRequest request) {
 		Long memberId = MemberLoader.getMemberId();
-		DeleteMemberParameter deleteMemberParameter =
-			DeleteMemberParameter.of(memberId, deleteMemberRequest.password());
-		memberService.deleteMember(deleteMemberParameter);
+
+		DeleteMemberParameter parameter = DeleteMemberParameter.of(memberId, request.password());
+
+		memberService.deleteMember(parameter);
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping("/profile/presigned/{filename}")
 	public ResponseEntity<DataResponse<CreatePresignedUrlResponse>> createProfileImagePreSignedUrl(
-		@Valid @PathVariable("filename") String filename) {
+		@PathVariable("filename") String filename
+	) {
 		CreatePresignedUrlRequest createPresignedUrlRequest = CreatePresignedUrlRequest.of(filename);
+
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(DataResponse.created(s3Service.createProfilePresignedUrl(createPresignedUrlRequest)));
 	}
 
 	@PostMapping("/profile/success")
-	public ResponseEntity<DataResponse<Void>> saveProfileImageMetaData(@RequestBody SaveFileMetaDataRequest request) {
+	public ResponseEntity<DataResponse<Void>> saveProfileImageMetaData(
+		@RequestBody @Valid SaveFileMetaDataRequest request
+	) {
 		Long memberId = MemberLoader.getMemberId();
-		SaveFileMetaDataParameter parameter = SaveFileMetaDataParameter.from(memberId, request);
+
+		SaveFileMetaDataParameter parameter = SaveFileMetaDataParameter.of(memberId, request);
+
 		memberService.saveProfileImageMetaData(parameter);
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@DeleteMapping("/profile")
 	public ResponseEntity<DataResponse<Void>> deleteProfileImage() {
 		Long memberId = MemberLoader.getMemberId();
-		DeleteProfileImageParameter parameter = DeleteProfileImageParameter.of(memberId);
+
+		DeleteProfileImageParameter parameter = DeleteProfileImageParameter.from(memberId);
+
 		memberService.deleteProfileImage(parameter);
+
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(DataResponse.noContent());
 	}
 
 	@PostMapping(value = "/login", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-	public ResponseEntity<DataResponse<Void>> loginMember(@RequestParam("email") String email,
-		@RequestParam("password") String password) {
+	public ResponseEntity<DataResponse<Void>> loginMember(
+		@RequestParam("email") String email,
+		@RequestParam("password") String password
+	) {
 		// 실제로 실행되지 않고 Swagger 문서용도로만 사용됩니다.
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -119,10 +137,14 @@ public class MemberController {
 	// 비밀번호 수정(현재 비밀번호 확인)
 	@PutMapping("/password")
 	public ResponseEntity<DataResponse<Void>> updatePassword(
-		@Valid @RequestBody UpdatePasswordRequest updatePasswordRequest) {
+		@Valid @RequestBody UpdatePasswordRequest updatePasswordRequest
+	) {
 		Long memberId = MemberLoader.getMemberId();
-		UpdatePasswordParameter parameter = UpdatePasswordParameter.from(memberId, updatePasswordRequest);
+
+		UpdatePasswordParameter parameter = UpdatePasswordParameter.of(memberId, updatePasswordRequest);
+
 		memberService.updatePassword(parameter);
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
@@ -140,9 +162,9 @@ public class MemberController {
 	public ResponseEntity<DataResponse<NicknameExistsResponse>> checkNicknameExists(
 		@PathVariable("nickname") String nickname
 	) {
-		CheckNicknameExistsRequest request = CheckNicknameExistsRequest.of(nickname);
+		CheckNicknameExistsRequest request = CheckNicknameExistsRequest.from(nickname);
 
-		NicknameExistsResponse exist = NicknameExistsResponse.of(memberService.isNicknameExists(request));
+		NicknameExistsResponse exist = NicknameExistsResponse.from(memberService.isNicknameExists(request));
 
 		return ResponseEntity.status(HttpStatus.OK).body(DataResponse.from(exist));
 	}
@@ -153,7 +175,7 @@ public class MemberController {
 	) {
 		Long memberId = MemberLoader.getMemberId();
 
-		UpdateNicknameParameter parameter = UpdateNicknameParameter.from(memberId, updateNicknameRequest);
+		UpdateNicknameParameter parameter = UpdateNicknameParameter.of(memberId, updateNicknameRequest);
 		memberService.updateNickname(parameter);
 
 		return ResponseEntity.status(HttpStatus.CREATED)

--- a/backend/src/main/java/aimo/backend/domains/member/dto/parameter/DeleteMemberContentsParameter.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/parameter/DeleteMemberContentsParameter.java
@@ -2,7 +2,7 @@ package aimo.backend.domains.member.dto.parameter;
 
 public record DeleteMemberContentsParameter(Long memberId) {
 
-	public static DeleteMemberContentsParameter of(Long memberId) {
+	public static DeleteMemberContentsParameter from(Long memberId) {
 		return new DeleteMemberContentsParameter(memberId);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/dto/parameter/DeleteProfileImageParameter.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/parameter/DeleteProfileImageParameter.java
@@ -2,7 +2,7 @@ package aimo.backend.domains.member.dto.parameter;
 
 public record DeleteProfileImageParameter(Long memberId) {
 
-	public static DeleteProfileImageParameter of(Long memberId) {
+	public static DeleteProfileImageParameter from(Long memberId) {
 		return new DeleteProfileImageParameter(memberId);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/dto/parameter/SaveFileMetaDataParameter.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/parameter/SaveFileMetaDataParameter.java
@@ -13,7 +13,7 @@ public record SaveFileMetaDataParameter(
 		return new SaveFileMetaDataParameter(memberId, filename, extension, size);
 	}
 
-	public static SaveFileMetaDataParameter from(Long memberId, SaveFileMetaDataRequest request) {
+	public static SaveFileMetaDataParameter of(Long memberId, SaveFileMetaDataRequest request) {
 		return new SaveFileMetaDataParameter(memberId, request.filename(), request.extension(), request.size());
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/dto/parameter/UpdateNicknameParameter.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/parameter/UpdateNicknameParameter.java
@@ -11,7 +11,7 @@ public record UpdateNicknameParameter(
 		return new UpdateNicknameParameter(memberId, newNickname);
 	}
 
-	public static UpdateNicknameParameter from(Long memberId, UpdateNicknameRequest request) {
+	public static UpdateNicknameParameter of(Long memberId, UpdateNicknameRequest request) {
 		return new UpdateNicknameParameter(
 			memberId,
 			request.newNickname()

--- a/backend/src/main/java/aimo/backend/domains/member/dto/parameter/UpdatePasswordParameter.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/parameter/UpdatePasswordParameter.java
@@ -12,7 +12,7 @@ public record UpdatePasswordParameter(
 		return new UpdatePasswordParameter(memberId, password, newPassword);
 	}
 
-	public static UpdatePasswordParameter from(Long memberId, UpdatePasswordRequest updatePasswordRequest) {
+	public static UpdatePasswordParameter of(Long memberId, UpdatePasswordRequest updatePasswordRequest) {
 		return new UpdatePasswordParameter(
 			memberId,
 			updatePasswordRequest.password(),

--- a/backend/src/main/java/aimo/backend/domains/member/dto/request/CheckNicknameExistsRequest.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/request/CheckNicknameExistsRequest.java
@@ -3,7 +3,7 @@ package aimo.backend.domains.member.dto.request;
 public record CheckNicknameExistsRequest(
 	String nickname
 ) {
-	public static CheckNicknameExistsRequest of(String nickname) {
+	public static CheckNicknameExistsRequest from(String nickname) {
 		return new CheckNicknameExistsRequest(nickname);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/dto/request/DeleteMemberRequest.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/request/DeleteMemberRequest.java
@@ -2,7 +2,7 @@ package aimo.backend.domains.member.dto.request;
 
 public record DeleteMemberRequest(String password) {
 
-	public static DeleteMemberRequest of(String password) {
+	public static DeleteMemberRequest from(String password) {
 		return new DeleteMemberRequest(password);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/dto/request/LogoutRequest.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/request/LogoutRequest.java
@@ -2,7 +2,7 @@ package aimo.backend.domains.member.dto.request;
 
 public record LogoutRequest(String accessToken) {
 
-	public static LogoutRequest of(String accessToken) {
+	public static LogoutRequest from(String accessToken) {
 		return new LogoutRequest(accessToken);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/dto/request/UpdateNicknameRequest.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/request/UpdateNicknameRequest.java
@@ -2,7 +2,7 @@ package aimo.backend.domains.member.dto.request;
 
 public record UpdateNicknameRequest(String newNickname) {
 
-	public static UpdateNicknameRequest of(String newNickname) {
+	public static UpdateNicknameRequest from(String newNickname) {
 		return new UpdateNicknameRequest(newNickname);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/dto/response/NicknameExistsResponse.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/response/NicknameExistsResponse.java
@@ -2,7 +2,7 @@ package aimo.backend.domains.member.dto.response;
 
 public record NicknameExistsResponse(boolean exists) {
 
-	public static NicknameExistsResponse of(boolean exists) {
+	public static NicknameExistsResponse from(boolean exists) {
 		return new NicknameExistsResponse(exists);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/member/entity/Member.java
+++ b/backend/src/main/java/aimo/backend/domains/member/entity/Member.java
@@ -71,7 +71,7 @@ public class Member extends BaseEntity {
 	@Column(nullable = false, name = "birth_date")
 	private LocalDate birthDate;
 
-	@OneToMany(mappedBy = "member")
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<PrivatePost> privatePosts = new ArrayList<>();
 
 	@OneToMany(mappedBy = "member")

--- a/backend/src/main/java/aimo/backend/domains/member/service/MemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/member/service/MemberService.java
@@ -1,42 +1,44 @@
 package aimo.backend.domains.member.service;
 
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import aimo.backend.common.exception.ApiException;
 import aimo.backend.common.exception.ErrorCode;
 import aimo.backend.domains.auth.security.jwtFilter.JwtTokenProvider;
 import aimo.backend.domains.comment.entity.ChildComment;
 import aimo.backend.domains.comment.entity.ParentComment;
-import aimo.backend.domains.member.dto.parameter.UpdateNicknameParameter;
 import aimo.backend.domains.member.dto.parameter.DeleteMemberContentsParameter;
 import aimo.backend.domains.member.dto.parameter.DeleteMemberParameter;
 import aimo.backend.domains.member.dto.parameter.DeleteProfileImageParameter;
 import aimo.backend.domains.member.dto.parameter.FindMyInfoParameter;
 import aimo.backend.domains.member.dto.parameter.SaveFileMetaDataParameter;
 import aimo.backend.domains.member.dto.parameter.SignUpParameter;
+import aimo.backend.domains.member.dto.parameter.UpdateNicknameParameter;
 import aimo.backend.domains.member.dto.parameter.UpdatePasswordParameter;
 import aimo.backend.domains.member.dto.request.CheckNicknameExistsRequest;
-import aimo.backend.domains.member.dto.response.FindMyInfoResponse;
 import aimo.backend.domains.member.dto.request.LogoutRequest;
 import aimo.backend.domains.member.dto.request.SendTemporaryPasswordRequest;
+import aimo.backend.domains.member.dto.response.FindMyInfoResponse;
 import aimo.backend.domains.member.entity.Member;
 import aimo.backend.domains.member.entity.ProfileImage;
 import aimo.backend.domains.member.repository.MemberRepository;
 import aimo.backend.domains.member.repository.ProfileImageRepository;
 import aimo.backend.domains.post.dto.parameter.SoftDeletePostParameter;
+import aimo.backend.domains.post.entity.Post;
 import aimo.backend.domains.post.service.PostService;
-import aimo.backend.infrastructure.s3.dto.parameter.CreateResourceUrlParameter;
+import aimo.backend.domains.privatePost.service.PrivatePostMemberService;
 import aimo.backend.infrastructure.s3.S3Service;
+import aimo.backend.infrastructure.s3.dto.parameter.CreateResourceUrlParameter;
 import aimo.backend.infrastructure.s3.model.PresignedUrlPrefix;
 import aimo.backend.infrastructure.smtp.MailService;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -51,6 +53,7 @@ public class MemberService {
 	private final S3Service s3Service;
 	private final MailService mailService;
 	private final PostService postService;
+	private final PrivatePostMemberService privatePostMemberService;
 
 	// 이메일로 멤버 조회
 	public Optional<Member> findByEmail(String email) {
@@ -70,8 +73,9 @@ public class MemberService {
 
 	//로그아웃
 	@Transactional(rollbackFor = ApiException.class)
-	public void logoutMember(LogoutRequest logOutRequest) {
-		String accessToken = logOutRequest.accessToken();
+	public void logoutMember(LogoutRequest request) {
+		String accessToken = request.accessToken();
+
 		jwtTokenProvider.expireTokens(accessToken);
 	}
 
@@ -83,10 +87,28 @@ public class MemberService {
 		checkPassword(deleteMemberParameter.password(), member.getPassword());
 
 		// 멤버 컨텐츠 삭제
-		deleteMemberContents(DeleteMemberContentsParameter.of(member.getId()));
+		deleteMemberContents(DeleteMemberContentsParameter.from(member.getId()));
 		memberRepository.delete(member);
 	}
 
+	// 멤버 컨텐츠 소프트 삭제
+	private void deleteMemberContents(DeleteMemberContentsParameter parameter) {
+		Member member = findMemberById(parameter.memberId());
+
+		// 개인 글은 cascade로 삭제
+
+		// 포스트 이름 삭제
+		member.getPosts()
+			.forEach(Post::softDelete);
+		// 부모 댓글 이름 삭제
+		member.getParentComments()
+			.forEach(ParentComment::deleteParentCommentSoftly);
+		// 자식 댓글 이름 삭제
+		member.getChildComments()
+			.forEach(ChildComment::deleteChildCommentSoftly);
+	}
+
+	// 프로필 이미지 메타데이터 저장
 	@Transactional(rollbackFor = ApiException.class)
 	public void saveProfileImageMetaData(SaveFileMetaDataParameter parameter) {
 		Long memberId = parameter.memberId();
@@ -106,27 +128,29 @@ public class MemberService {
 	}
 
 	@Transactional(rollbackFor = ApiException.class)
-	public void deleteProfileImage(DeleteProfileImageParameter deleteProfileImageParameter) {
-		Member member = findMemberById(deleteProfileImageParameter.memberId());
+	public void deleteProfileImage(DeleteProfileImageParameter parameter) {
+		Member member = findMemberById(parameter.memberId());
 		ProfileImage profileImage = member.getProfileImage();
 		profileImageRepository.delete(profileImage);
 		member.updateProfileImage(null);
 	}
 
 	@Transactional(rollbackFor = ApiException.class)
-	public void updatePassword(UpdatePasswordParameter updatePasswordParameter) {
-		Member member = findMemberById(updatePasswordParameter.memberId());
+	public void updatePassword(UpdatePasswordParameter parameter) {
+		Member member = findMemberById(parameter.memberId());
 
-		checkPassword(updatePasswordParameter.password(), member.getPassword());
+		checkPassword(parameter.password(), member.getPassword());
 
-		member.updatePassword(passwordEncoder.encode(updatePasswordParameter.newPassword()));
+		member.updatePassword(passwordEncoder.encode(parameter.newPassword()));
 	}
 
 	// 닉네임 변경
 	@Transactional(rollbackFor = ApiException.class)
 	public void updateNickname(UpdateNicknameParameter parameter) {
 		Member member = findMemberById(parameter.memberId());
+
 		validateDuplicateNickname(parameter.newNickname());
+
 		member.updateNickname(parameter.newNickname());
 	}
 
@@ -155,24 +179,6 @@ public class MemberService {
 		}
 	}
 
-	// 멤버 컨텐츠 소프트 삭제
-	private void deleteMemberContents(DeleteMemberContentsParameter parameter) {
-		Member member = findMemberById(parameter.memberId());
-
-		member.getPosts()
-			.forEach(post -> postService.softDeleteBy(new SoftDeletePostParameter(post.getId())));
-		member.getParentComments()
-			.stream()
-			.filter(parentComment -> !parentComment.getIsDeleted())
-			.forEach(ParentComment::deleteParentCommentSoftly);
-
-		member.getChildComments()
-			.stream()
-			.filter(childComment -> !childComment.getIsDeleted())
-			.forEach(ChildComment::deleteChildCommentSoftly);
-
-	}
-
 	// 이메일 중복 검사
 	private void validateDuplicateEmail(String email) {
 		if (memberRepository.existsByEmail(email))
@@ -185,6 +191,7 @@ public class MemberService {
 			throw ApiException.from(ErrorCode.MEMBER_NAME_DUPLICATE);
 	}
 
+	// 임시 비밀번호 발급
 	@Transactional(rollbackFor = ApiException.class)
 	public void updateTemporaryPasswordAndSendMail(
 		SendTemporaryPasswordRequest sendTemporaryPasswordRequest) throws MessagingException {

--- a/backend/src/main/java/aimo/backend/domains/post/dto/parameter/SoftDeletePostParameter.java
+++ b/backend/src/main/java/aimo/backend/domains/post/dto/parameter/SoftDeletePostParameter.java
@@ -1,9 +1,10 @@
 package aimo.backend.domains.post.dto.parameter;
 
 public record SoftDeletePostParameter(
-	Long postId
+	Long postId,
+	Long memberId
 ) {
-	public static SoftDeletePostParameter of(Long postId) {
-		return new SoftDeletePostParameter(postId);
+	public static SoftDeletePostParameter of(Long postId, Long memberId) {
+		return new SoftDeletePostParameter(postId, memberId);
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/aimo/backend/domains/post/entity/Post.java
@@ -114,8 +114,8 @@ public class Post extends BaseEntity {
 	public Integer getCommentsCount() {
 		return parentComments
 			.stream()
-			.map(ParentComment::getChildCommentsCount)
-			.reduce(1, Integer::sum);
+			.map(parentComment -> 1 + parentComment.getChildCommentsCount())
+			.reduce(0, Integer::sum);
 	}
 
 	public String getPreview(){

--- a/backend/src/main/java/aimo/backend/domains/post/model/PostType.java
+++ b/backend/src/main/java/aimo/backend/domains/post/model/PostType.java
@@ -1,16 +1,46 @@
+// PostType Enum에 각 타입에 따른 메서드 구현
 package aimo.backend.domains.post.model;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import aimo.backend.domains.post.dto.parameter.FindPostByPostTypeParameter;
+import aimo.backend.domains.post.dto.response.FindPostsByPostTypeResponse;
+import aimo.backend.domains.post.service.PostService;
 
 public enum PostType {
 
-	MY("내가 쓴 글"),
-	COMMENTED("댓글 단 글"),
-	POPULAR("인기 글"),
-	ANY("전체 글"),
-	;
+	MY("내가 쓴 글") {
+		@Override
+		public Page<FindPostsByPostTypeResponse> findPosts(PostService service, FindPostByPostTypeParameter parameter, Pageable pageable) {
+			return service.findMyPosts(parameter.memberId(), pageable);
+		}
+	},
+	COMMENTED("댓글 단 글") {
+		@Override
+		public Page<FindPostsByPostTypeResponse> findPosts(PostService service, FindPostByPostTypeParameter parameter, Pageable pageable) {
+			return service.findCommentedPosts(parameter.memberId(), pageable);
+		}
+	},
+	POPULAR("인기 글") {
+		@Override
+		public Page<FindPostsByPostTypeResponse> findPosts(PostService service, FindPostByPostTypeParameter parameter, Pageable pageable) {
+			return service.findPopularPosts(pageable);
+		}
+	},
+	ANY("전체 글") {
+		@Override
+		public Page<FindPostsByPostTypeResponse> findPosts(PostService service, FindPostByPostTypeParameter parameter, Pageable pageable) {
+			return service.findAnyPosts(pageable);
+		}
+	};
 
 	private final String value;
 
 	PostType(String value) {
 		this.value = value;
 	}
+
+	// 각 PostType에 따라 다른 로직을 수행할 추상 메서드 정의
+	public abstract Page<FindPostsByPostTypeResponse> findPosts(PostService service, FindPostByPostTypeParameter parameter, Pageable pageable);
 }

--- a/backend/src/main/java/aimo/backend/domains/post/service/PostMemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/post/service/PostMemberService.java
@@ -29,6 +29,7 @@ public class PostMemberService {
 	private final MemberRepository memberRepository;
 	private final PrivatePostMemberService privatePostMemberService;
 
+	// 글 저장
 	@Transactional
 	public Long save(SavePostParameter savePostParameter) {
 		Member member = memberRepository.findById(savePostParameter.memberId())

--- a/backend/src/main/java/aimo/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/aimo/backend/domains/post/service/PostService.java
@@ -62,12 +62,17 @@ public class PostService {
 			parameter.size(),
 			Sort.by(Sort.Direction.DESC, "id"));
 
-		if (postType == PostType.MY) 		posts = findMyPosts(parameter.memberId(), pageable);
-		if (postType == PostType.ANY) 		posts = findAnyPosts(pageable);
-		if (postType == PostType.POPULAR) 	posts = findPopularPosts(pageable);
-		if (postType == PostType.COMMENTED) posts = findCommentedPosts(parameter.memberId(), pageable);
+		if (postType == PostType.MY)
+			posts = findMyPosts(parameter.memberId(), pageable);
+		if (postType == PostType.ANY)
+			posts = findAnyPosts(pageable);
+		if (postType == PostType.POPULAR)
+			posts = findPopularPosts(pageable);
+		if (postType == PostType.COMMENTED)
+			posts = findCommentedPosts(parameter.memberId(), pageable);
 
-		if(posts == null) throw ApiException.from(POST_TYPE_NOT_FOUND);
+		if (posts == null)
+			throw ApiException.from(POST_TYPE_NOT_FOUND);
 
 		return posts;
 	}
@@ -130,7 +135,7 @@ public class PostService {
 	// 글 삭제
 	@Transactional
 	public void deletePostBy(DeletePostParameter parameter) {
-		Long postId   = parameter.postId();
+		Long postId = parameter.postId();
 		Long memberId = parameter.memberId();
 
 		validateDeletePost(memberId, postId);
@@ -151,14 +156,5 @@ public class PostService {
 		if (!exists) {
 			throw ApiException.from(POST_DELETE_UNAUTHORIZED);
 		}
-	}
-
-	public void softDeleteBy(SoftDeletePostParameter parameter) {
-		Long memberId = MemberLoader.getMemberId();
-		Post post = findById(parameter.postId());
-		DeletePrivatePostParameter deletePrivatePostParameter =
-			DeletePrivatePostParameter.of(memberId, post.getPrivatePostId());
-		privatePostMemberService.deletePrivatePostBy(deletePrivatePostParameter);
-		post.softDelete();
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/privatePost/controller/PrivatePostController.java
+++ b/backend/src/main/java/aimo/backend/domains/privatePost/controller/PrivatePostController.java
@@ -100,6 +100,7 @@ public class PrivatePostController {
 		@Valid @RequestBody SpeechToTextRequest speechToTextRequest
 	) {
 		SpeechToTextParameter parameter = SpeechToTextParameter.from(speechToTextRequest);
+
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(DataResponse.created(audioRecordService.speechToText(parameter)));
 	}
@@ -109,6 +110,7 @@ public class PrivatePostController {
 		@Valid @PathVariable("filename") String filename
 	) {
 		CreatePresignedUrlRequest createPresignedUrlRequest = CreatePresignedUrlRequest.of(filename);
+
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(DataResponse.created(s3Service.createAudioPreSignedUrl(createPresignedUrlRequest)));
 	}
@@ -118,6 +120,7 @@ public class PrivatePostController {
 		@Valid @RequestBody SaveAudioSuccessRequest saveAudioSuccessRequest
 	) {
 		SaveAudioSuccessParameter parameter = SaveAudioSuccessParameter.from(saveAudioSuccessRequest);
+
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(DataResponse.created(audioRecordService.save(parameter)));
 	}
@@ -128,7 +131,9 @@ public class PrivatePostController {
 		@Valid @PathVariable Long privatePostId
 	) {
 		Long memberId = MemberLoader.getMemberId();
+
 		FindPrivatePostParameter parameter = FindPrivatePostParameter.of(memberId, privatePostId);
+
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(DataResponse.from(privatePostMemberService.findPrivatePostResponseBy(parameter)));
 	}
@@ -139,8 +144,10 @@ public class PrivatePostController {
 		@Valid @RequestParam(defaultValue = "10") Integer size
 	) {
 		Long memberId = MemberLoader.getMemberId();
+
 		Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
 		FindPrivatePostPreviewParameter parameter = FindPrivatePostPreviewParameter.of(memberId, pageable);
+
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(DataResponse.from(privatePostMemberService.findPrivatePostPreviewsBy(parameter)));
 	}
@@ -150,8 +157,11 @@ public class PrivatePostController {
 		@Valid @PathVariable("privatePostId") Long privatePostId
 	) {
 		Long memberId = MemberLoader.getMemberId();
+
 		DeletePrivatePostParameter parameter = DeletePrivatePostParameter.of(memberId, privatePostId);
+
 		privatePostMemberService.deletePrivatePostBy(parameter);
+
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(DataResponse.noContent());
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/privatePost/service/PrivatePostMemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/privatePost/service/PrivatePostMemberService.java
@@ -78,9 +78,9 @@ public class PrivatePostMemberService {
 	public void deletePrivatePostBy(DeletePrivatePostParameter parameter) {
 		Long memberId = parameter.memberId();
 		Long privatePostId = parameter.privatePostId();
+
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> ApiException.from(ErrorCode.MEMBER_NOT_FOUND));
-
 		PrivatePost privatePost = privatePostRepository.findById(privatePostId)
 			.orElseThrow(() -> ApiException.from(ErrorCode.PRIVATE_POST_NOT_FOUND));
 

--- a/backend/src/main/java/aimo/backend/domains/view/controller/ViewController.java
+++ b/backend/src/main/java/aimo/backend/domains/view/controller/ViewController.java
@@ -23,11 +23,13 @@ public class ViewController {
 
 	@PostMapping("/{postId}/views")
 	public ResponseEntity<DataResponse<Void>> increasePostView(
-		@PathVariable("postId") Long postId) {
+		@PathVariable("postId") Long postId
+	) {
 		Long memberId = MemberLoader.getMemberId();
-		IncreasePostViewParameter increasePostViewParameter =
-			IncreasePostViewParameter.of(memberId, postId);
-		postViewMemberService.increasePostViewBy(increasePostViewParameter);
+
+		IncreasePostViewParameter parameter = IncreasePostViewParameter.of(memberId, postId);
+		postViewMemberService.increasePostViewBy(parameter);
+
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(DataResponse.created());

--- a/backend/src/main/java/aimo/backend/domains/view/service/PostViewMemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/view/service/PostViewMemberService.java
@@ -30,6 +30,7 @@ public class PostViewMemberService {
 	public void increasePostViewBy(IncreasePostViewParameter increasePostViewParameter) {
 		Long memberId = increasePostViewParameter.memberId();
 		Long postId = increasePostViewParameter.postId();
+
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 		Member member = memberRepository.findById(memberId)

--- a/backend/src/main/java/aimo/backend/domains/vote/controller/VoteController.java
+++ b/backend/src/main/java/aimo/backend/domains/vote/controller/VoteController.java
@@ -29,9 +29,10 @@ public class VoteController {
 		@RequestParam("side") Side side
 	) {
 		Long memberId = MemberLoader.getMemberId();
-		SaveVotePostParameter saveVotePostParameter =
-			SaveVotePostParameter.of(memberId, postId, side);
-		voteService.votePost(saveVotePostParameter);
+
+		SaveVotePostParameter parameter = SaveVotePostParameter.of(memberId, postId, side);
+		voteService.votePost(parameter);
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/vote/service/VoteService.java
+++ b/backend/src/main/java/aimo/backend/domains/vote/service/VoteService.java
@@ -33,7 +33,6 @@ public class VoteService {
 
 		voteRepository.findByPostIdAndMemberId(postId, member.getId())
 			.ifPresentOrElse(
-
 				(vote) -> vote.changeSide(side),
 				() -> {
 					Vote newVote = Vote.from(post, member, side);


### PR DESCRIPTION
## issue
- close #71

## 구현 의도
- 중복 코드 제거
- 가독성을 위한 코드 줄바꿈
- 메서드 명 구분(of, from)

## 구현 사항
### 중복 코드 제거
![image](https://github.com/user-attachments/assets/b78c6158-c565-462f-819e-994b33888b33)
![image](https://github.com/user-attachments/assets/a93fd79c-bade-458c-8b53-20a1b97145b6)
Post 목록 조회에서 if, elif 문을 반복하여 메서드를 찾아 호출하고  있었다.
이 메서드들을 파라미터를 받아 Page 응답을 하는 부분이 공통적이었다.
그래서 Enum 안의 메서드로 분리하여 각 Enum Type의 메서드를 호출하게 끔 변경하였다.


## 🫡 참고사항
