### PR TITLE
Feature: 로그 설정(#83)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -26,12 +26,9 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 
-application*
-backend/src/main/resources/application.yml
-!backend/src/main/resources/logback-spring.xml
 ### NetBeans ###
 /nbproject/private/
-/nbbuild/
+/nbbuild
 /dist/
 /nbdist/
 /.nb-gradle/
@@ -39,5 +36,4 @@ backend/src/main/resources/application.yml
 ### VS Code ###
 .vscode/
 
-### log ###
-log/*
+src/main/resources/application.yml

--- a/backend/src/main/resources/logback/console-appender.xml
+++ b/backend/src/main/resources/logback/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/src/main/resources/logback/file-error-appender.xml
+++ b/backend/src/main/resources/logback/file-error-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>build/libs/aimo-backend-prod-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/backend/src/main/resources/logback/file-info-appender.xml
+++ b/backend/src/main/resources/logback/file-info-appender.xml
@@ -1,0 +1,13 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>build/libs/aimo-backend-dev-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/backend/src/main/resources/logback/logback-spring.xml
+++ b/backend/src/main/resources/logback/logback-spring.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration scan="true" scanPeriod="60 seconds">
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!--CONSOLE에 찍히는 로그와 FILE에 찍히는 로그 다르게(색상 유무)-->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+
+
+    <!--프로필별로 로그 설정-->
+    <!--local: 콘솔에 출력-->
+    <springProfile name="local">
+
+        <include resource="logback/console-appender.xml"/>
+        <include resource="logback/file-info-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+        </root>
+
+        <logger level="INFO" name="aimo.backend"/>
+
+        <logger level="DEBUG" name="org.hibernate.SQL">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+
+        <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+    </springProfile>
+
+    <!--dev:콘솔, 파일 둘다 출력-->
+    <springProfile name="dev">
+
+        <include resource="logback/console-appender.xml"/>
+        <include resource="logback/file-info-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+        </root>
+
+        <logger level="INFO" name="aimo.backend"/>
+
+        <logger level="DEBUG" name="org.hibernate.SQL">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+
+        <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+    </springProfile>
+
+</configuration>
+
+
+
+


### PR DESCRIPTION
## issue
- close #83 

## 구현 의도
- dev로 배포가  됐을 때에 콘솔과 파일에 쓰이도록 한다.
- 로컬에서는 콘솔에만 쓰이도록 한다.

## 구현 사항
- 로그 파일은 날짜별로 쌓이도록 했다.
- 로그는 최대 30일까지 보관되도록했다.
- 각 파일은 50MB로 잡았고, 이를 넘으면 버전이 올라가도록했다.
- 로그파일 총 용량은 1GB로 잡았다.

