### PR TITLE
Feature/90 caching list api

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,7 +16,7 @@ java {
 
 jar {
     archiveBaseName.set("backend-server")
-    archiveVersion .set('')
+    archiveVersion.set('')
 }
 
 configurations {
@@ -56,6 +56,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.security:spring-security-crypto:5.7.1'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
@@ -75,6 +76,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     //rabbitmq
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/aimo/backend/common/dto/PageResponse.java
+++ b/backend/src/main/java/aimo/backend/common/dto/PageResponse.java
@@ -1,0 +1,37 @@
+package aimo.backend.common.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageResponse<T> {
+	private List<T> content;
+	private int currentPage;
+	private int totalPages;
+	private long totalItems;
+
+	private PageResponse(List<T> content, int number, int totalPages, long totalElements) {
+		this.content = content;
+		this.currentPage = number;
+		this.totalPages = totalPages;
+		this.totalItems = totalElements;
+	}
+
+	public static <T> PageResponse<T> from(Page<T> page) {
+		return new PageResponse<>(
+			page.getContent(),
+			page.getNumber(),
+			page.getTotalPages(),
+			page.getTotalElements()
+		);
+	}
+}

--- a/backend/src/main/java/aimo/backend/common/redis/RedisCacheConfig.java
+++ b/backend/src/main/java/aimo/backend/common/redis/RedisCacheConfig.java
@@ -1,0 +1,42 @@
+package aimo.backend.common.redis;
+
+import java.time.Duration;
+
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화
+public class RedisCacheConfig {
+
+	// 기본 캐시 전략
+	@Bean
+	public RedisCacheConfiguration redisCacheConfiguration() {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofSeconds(60))
+			.disableCachingNullValues()
+			.serializeKeysWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+			)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+			);
+	}
+
+	// 커스텀 캐시 전략
+	@Bean
+	public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+		return (builder) -> builder
+			.withCacheConfiguration("shortTermCache",
+				RedisCacheConfiguration.defaultCacheConfig()
+					.entryTtl(Duration.ofMinutes(1)) // cache1에 TTL 1분
+					.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+					.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())));
+	}
+}

--- a/backend/src/main/java/aimo/backend/common/redis/RedisCacheConfig.java
+++ b/backend/src/main/java/aimo/backend/common/redis/RedisCacheConfig.java
@@ -11,6 +11,8 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @Configuration
 @EnableCaching // Spring Boot의 캐싱 설정을 활성화
 public class RedisCacheConfig {
@@ -19,14 +21,12 @@ public class RedisCacheConfig {
 	@Bean
 	public RedisCacheConfiguration redisCacheConfiguration() {
 		return RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(Duration.ofSeconds(60))
-			.disableCachingNullValues()
-			.serializeKeysWith(
-				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
-			)
-			.serializeValuesWith(
-				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
-			);
+			.entryTtl(Duration.ofMinutes(1)) // TTL 설정
+			.disableCachingNullValues() // null 값 캐싱 방지
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+				new GenericJackson2JsonRedisSerializer(new ObjectMapper()) // Custom ObjectMapper 사용
+			));
 	}
 
 	// 커스텀 캐시 전략
@@ -36,7 +36,9 @@ public class RedisCacheConfig {
 			.withCacheConfiguration("shortTermCache",
 				RedisCacheConfiguration.defaultCacheConfig()
 					.entryTtl(Duration.ofMinutes(1)) // cache1에 TTL 1분
-					.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-					.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())));
+					.serializeKeysWith(
+						RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+					.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+						new GenericJackson2JsonRedisSerializer())));
 	}
 }

--- a/backend/src/main/java/aimo/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/aimo/backend/domains/post/controller/PostController.java
@@ -1,6 +1,5 @@
 package aimo.backend.domains.post.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import aimo.backend.common.dto.DataResponse;
+import aimo.backend.common.dto.PageResponse;
 import aimo.backend.common.util.memberLoader.MemberLoader;
 import aimo.backend.domains.post.dto.parameter.DeletePostParameter;
 import aimo.backend.domains.post.dto.parameter.FindPostAndCommentsByIdParameter;
@@ -51,7 +51,7 @@ public class PostController {
 	}
 
 	@GetMapping
-	public ResponseEntity<DataResponse<Page<FindPostsByPostTypeResponse>>> findPostsByPostType(
+	public ResponseEntity<DataResponse<PageResponse<FindPostsByPostTypeResponse>>> findPostsByPostType(
 		@RequestParam("type") @NotNull PostType postType,
 		@RequestParam("page") @NotNull Integer page,
 		@RequestParam("size") @NotNull Integer size
@@ -60,7 +60,8 @@ public class PostController {
 
 		FindPostByPostTypeParameter parameter = FindPostByPostTypeParameter.of(memberId, postType, page, size);
 
-		return ResponseEntity.ok(DataResponse.from(postService.findPostDtosByPostType(parameter)));
+		PageResponse<FindPostsByPostTypeResponse> responses = postService.findPostDtosByPostType(parameter);
+		return ResponseEntity.ok(DataResponse.from(responses));
 	}
 
 	@GetMapping("/{postId}")

--- a/backend/src/main/java/aimo/backend/domains/post/dto/response/FindPostsByPostTypeResponse.java
+++ b/backend/src/main/java/aimo/backend/domains/post/dto/response/FindPostsByPostTypeResponse.java
@@ -3,21 +3,28 @@ package aimo.backend.domains.post.dto.response;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import aimo.backend.domains.post.dto.requset.FindCommentedPostsByIdRequest;
 import aimo.backend.domains.post.entity.Post;
 
 public record FindPostsByPostTypeResponse(
-		Long id,
-		String title,
-		String contentPreview,
-		Integer likesCount,
-		Integer viewsCount,
-		Integer commentsCount,
-		Float voteRatePlaintiff,
-		Float voteRateDefendant,
-		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-		LocalDateTime createdAt
+	Long id,
+	String title,
+	String contentPreview,
+	Integer likesCount,
+	Integer viewsCount,
+	Integer commentsCount,
+	Float voteRatePlaintiff,
+	Float voteRateDefendant,
+
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+	LocalDateTime createdAt
 ) {
 
 	public static FindPostsByPostTypeResponse from(FindCommentedPostsByIdRequest request) {

--- a/backend/src/main/java/aimo/backend/domains/privatePost/controller/PrivatePostController.java
+++ b/backend/src/main/java/aimo/backend/domains/privatePost/controller/PrivatePostController.java
@@ -1,6 +1,5 @@
 package aimo.backend.domains.privatePost.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import aimo.backend.common.dto.DataResponse;
+import aimo.backend.common.dto.PageResponse;
 import aimo.backend.common.util.memberLoader.MemberLoader;
 import aimo.backend.domains.privatePost.dto.parameter.DeletePrivatePostParameter;
 import aimo.backend.domains.privatePost.dto.parameter.FindPrivatePostParameter;
@@ -104,7 +104,7 @@ public class PrivatePostController {
 	}
 
 	@GetMapping
-	public ResponseEntity<DataResponse<Page<PrivatePostPreviewResponse>>> findPrivatePostPage(
+	public ResponseEntity<DataResponse<PageResponse<PrivatePostPreviewResponse>>> findPrivatePostPage(
 		@Valid @RequestParam(defaultValue = "0") Integer page,
 		@Valid @RequestParam(defaultValue = "10") Integer size
 	) {

--- a/backend/src/main/java/aimo/backend/domains/privatePost/service/PrivatePostService.java
+++ b/backend/src/main/java/aimo/backend/domains/privatePost/service/PrivatePostService.java
@@ -11,6 +11,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import aimo.backend.common.dto.PageResponse;
 import aimo.backend.common.exception.ApiException;
 import aimo.backend.common.exception.ErrorCode;
 import aimo.backend.common.messageQueue.MessageQueueService;
@@ -141,6 +142,7 @@ public class PrivatePostService {
 
 		return PrivatePostResponse.from(privatePost);
 	}
+
 	// 개인글 상태에 따른 에러 리턴 및 실패시 개인글 삭제
 	@Transactional(rollbackFor = ApiException.class)
 	public void validatePrivatePostStatus(PrivatePost privatePost) {
@@ -167,9 +169,13 @@ public class PrivatePostService {
 	}
 
 	// 개인글 목록 조회
-	public Page<PrivatePostPreviewResponse> findPrivatePostPreviewsBy(FindPrivatePostPreviewParameter parameter) {
-		return privatePostRepository.findByMemberId(parameter.memberId(), parameter.pageable())
+	public PageResponse<PrivatePostPreviewResponse> findPrivatePostPreviewsBy(
+		FindPrivatePostPreviewParameter parameter) {
+		Page<PrivatePostPreviewResponse> privatePosts = privatePostRepository.findByMemberId(parameter.memberId(),
+				parameter.pageable())
 			.map(PrivatePostPreviewResponse::from);
+
+		return PageResponse.from(privatePosts);
 	}
 
 	// 개인글 공개 처리


### PR DESCRIPTION
## issue
- close #90

## 구현 의도
- 인기 게시글 목록 조회 기능은 가장 많이 사용되는 API이므로 사용자 경험 향상을 위해 추가적인 성능 개선이 필요해짐

## 구현 사항
- Caching을 고려하여  개선
- 자주 조회되는 목록은 캐싱
- Caching을 위해, 인메모리 DB Redis를 도입
성과
- 1명의 유저에 대해 캐시 HIT 발생시, 응답시간이 0.35s → 0.085s로 3배 개선
![image](https://github.com/user-attachments/assets/f7c93787-ff5c-4495-942c-0b8ca5f250d8)
