### PR TITLE
Feature: Oauth 로직 수정(#96)

### DIFF
--- a/backend/src/main/java/aimo/backend/common/security/dto/OAuth2UserInfo.java
+++ b/backend/src/main/java/aimo/backend/common/security/dto/OAuth2UserInfo.java
@@ -35,7 +35,7 @@ public class OAuth2UserInfo {
 
 		return OAuth2UserInfo.builder()
 			.provider(Provider.KAKAO)
-			.email(kakaoOAuth2Response.email())
+			.email(Provider.KAKAO + " - " +kakaoOAuth2Response.email())
 			.name(kakaoOAuth2Response.nickname())
 			.providerId(kakaoOAuth2Response.id())
 			.build();

--- a/backend/src/main/java/aimo/backend/domains/member/controller/MemberController.java
+++ b/backend/src/main/java/aimo/backend/domains/member/controller/MemberController.java
@@ -5,7 +5,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +20,6 @@ import aimo.backend.domains.member.dto.parameter.FindMyInfoParameter;
 import aimo.backend.domains.member.dto.parameter.SignUpParameter;
 import aimo.backend.domains.member.dto.parameter.UpdateNicknameParameter;
 import aimo.backend.domains.member.dto.parameter.UpdatePasswordParameter;
-import aimo.backend.domains.member.dto.request.CheckNicknameExistsRequest;
 import aimo.backend.domains.member.dto.request.DeleteMemberRequest;
 import aimo.backend.domains.member.dto.request.LogoutRequest;
 import aimo.backend.domains.member.dto.request.SendNewPasswordRequest;
@@ -29,7 +27,6 @@ import aimo.backend.domains.member.dto.request.SignUpRequest;
 import aimo.backend.domains.member.dto.request.UpdateNicknameRequest;
 import aimo.backend.domains.member.dto.request.UpdatePasswordRequest;
 import aimo.backend.domains.member.dto.response.FindMyInfoResponse;
-import aimo.backend.domains.member.dto.response.NicknameExistsResponse;
 import aimo.backend.domains.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -144,18 +141,6 @@ public class MemberController {
 		memberService.validateCodeAndSendNewPassword(request);
 
 		return ResponseEntity.ok(DataResponse.ok());
-	}
-
-	// 닉네임 중복 확인
-	@GetMapping("/nickname/{nickname}/exists")
-	public ResponseEntity<DataResponse<NicknameExistsResponse>> checkNicknameExists(
-		@PathVariable("nickname") String nickname
-	) {
-		CheckNicknameExistsRequest request = CheckNicknameExistsRequest.from(nickname);
-
-		NicknameExistsResponse exist = NicknameExistsResponse.from(memberService.isNicknameExists(request));
-
-		return ResponseEntity.status(HttpStatus.OK).body(DataResponse.from(exist));
 	}
 
 	// 닉네임 수정

--- a/backend/src/main/java/aimo/backend/domains/member/dto/response/NicknameExistsResponse.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/response/NicknameExistsResponse.java
@@ -1,8 +1,0 @@
-package aimo.backend.domains.member.dto.response;
-
-public record NicknameExistsResponse(boolean exists) {
-
-	public static NicknameExistsResponse from(boolean exists) {
-		return new NicknameExistsResponse(exists);
-	}
-}

--- a/backend/src/main/java/aimo/backend/domains/member/entity/Member.java
+++ b/backend/src/main/java/aimo/backend/domains/member/entity/Member.java
@@ -9,15 +9,15 @@ import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.annotations.ColumnDefault;
 
+import aimo.backend.common.entity.BaseEntity;
 import aimo.backend.domains.comment.entity.ChildComment;
+import aimo.backend.domains.comment.entity.ParentComment;
 import aimo.backend.domains.member.dto.parameter.SignUpParameter;
-import aimo.backend.domains.privatePost.entity.PrivatePost;
 import aimo.backend.domains.member.model.Gender;
 import aimo.backend.domains.member.model.MemberRole;
 import aimo.backend.domains.member.model.Provider;
-import aimo.backend.common.entity.BaseEntity;
-import aimo.backend.domains.comment.entity.ParentComment;
 import aimo.backend.domains.post.entity.Post;
+import aimo.backend.domains.privatePost.entity.PrivatePost;
 import aimo.backend.domains.upload.entity.ProfileImage;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -47,7 +47,7 @@ public class Member extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String nickname;
 
 	@Column(nullable = false)

--- a/backend/src/main/java/aimo/backend/domains/member/service/MemberService.java
+++ b/backend/src/main/java/aimo/backend/domains/member/service/MemberService.java
@@ -20,7 +20,6 @@ import aimo.backend.domains.member.dto.parameter.FindMyInfoParameter;
 import aimo.backend.domains.member.dto.parameter.SignUpParameter;
 import aimo.backend.domains.member.dto.parameter.UpdateNicknameParameter;
 import aimo.backend.domains.member.dto.parameter.UpdatePasswordParameter;
-import aimo.backend.domains.member.dto.request.CheckNicknameExistsRequest;
 import aimo.backend.domains.member.dto.request.LogoutRequest;
 import aimo.backend.domains.member.dto.request.SendNewPasswordRequest;
 import aimo.backend.domains.member.dto.response.FindMyInfoResponse;
@@ -51,7 +50,6 @@ public class MemberService {
 	@Transactional(rollbackFor = ApiException.class)
 	public void signUp(SignUpParameter parameter) {
 		validateDuplicateEmail(parameter.email());
-		validateDuplicateNickname(parameter.nickname());
 
 		// 인증 토큰 확인
 		emailService.verifyEmailCode(
@@ -119,9 +117,6 @@ public class MemberService {
 			return;
 		}
 
-		// 닉네임 중복 검사
-		validateDuplicateNickname(parameter.newNickname());
-
 		member.updateNickname(parameter.newNickname());
 	}
 
@@ -134,11 +129,6 @@ public class MemberService {
 	private Member findMemberById(Long memberId) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> ApiException.from(ErrorCode.MEMBER_NOT_FOUND));
-	}
-
-	// 닉네임 중복 검사
-	public boolean isNicknameExists(CheckNicknameExistsRequest request) {
-		return memberRepository.existsByNickname(request.nickname());
 	}
 
 	// 비밀번호 확인
@@ -154,12 +144,6 @@ public class MemberService {
 	private void validateDuplicateEmail(String email) {
 		if (memberRepository.existsByEmailAndProvider(email, Provider.AIMO))
 			throw ApiException.from(ErrorCode.EMAIL_DUPLICATE);
-	}
-
-	// 닉네임 중복 검사
-	private void validateDuplicateNickname(String nickname) {
-		if (memberRepository.existsByNickname(nickname))
-			throw ApiException.from(ErrorCode.MEMBER_NAME_DUPLICATE);
 	}
 
 	// 비밀번호 재발급


### PR DESCRIPTION
## issue
- close #96 

## 구현 의도
- Oauth 회원가입시 발생할 수 있는 문제를 해결한다.

## 구현 사항
- Member 닉네임 중복 되도록 변경
- OAuth 회원가입시 Email 앞에 Provider넣도록  수정

## 🫡 참고사항
- 닉네임은 중복되면 안되지만, 발표 일정상 중복을 허용해뒀다. 추후 수정이 필요하다.