### PR TITLE
Feature/100 implement indexing

### DIFF
--- a/backend/src/main/java/aimo/backend/domains/ai/controller/AIController.java
+++ b/backend/src/main/java/aimo/backend/domains/ai/controller/AIController.java
@@ -21,7 +21,6 @@ import aimo.backend.domains.ai.service.AIService;
 import aimo.backend.domains.privatePost.dto.parameter.UpdateContentToPrivatePostParameter;
 import aimo.backend.domains.privatePost.dto.request.UploadTextRecordAndRequestJudgementRequest;
 import aimo.backend.domains.privatePost.model.OriginType;
-import aimo.backend.domains.privatePost.service.PrivatePostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 public class AIController {
 
 	private final AIService aiService;
-	private final PrivatePostService privatePostService;
 
 	@PostMapping("/private-posts/speech-to-text")
 	public ResponseEntity<DataResponse<Void>> speechToText(

--- a/backend/src/main/java/aimo/backend/domains/comment/entity/ChildComment.java
+++ b/backend/src/main/java/aimo/backend/domains/comment/entity/ChildComment.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -27,7 +28,13 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "child_comments")
+@Table(
+	name = "child_comments",
+	indexes = {
+		@Index(name = "child_comments_idx_member_id", columnList = "member_id"),
+		@Index(name = "child_comments_idx_post_id", columnList = "post_id")
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 public class ChildComment extends BaseEntity {
 

--- a/backend/src/main/java/aimo/backend/domains/comment/entity/ParentComment.java
+++ b/backend/src/main/java/aimo/backend/domains/comment/entity/ParentComment.java
@@ -16,7 +16,13 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "parent_comments")
+@Table(
+	name = "parent_comments",
+	indexes = {
+		@Index(name = "parent_comments_idx_member_id", columnList = "member_id"),
+		@Index(name = "parent_comments_idx_post_id", columnList = "post_id")
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 public class ParentComment extends BaseEntity {
 

--- a/backend/src/main/java/aimo/backend/domains/like/entity/ChildCommentLike.java
+++ b/backend/src/main/java/aimo/backend/domains/like/entity/ChildCommentLike.java
@@ -6,6 +6,7 @@ import aimo.backend.domains.comment.entity.ChildComment;
 import aimo.backend.domains.member.entity.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,7 +21,11 @@ import lombok.NoArgsConstructor;
 	name = "child_comment_likes",
 	uniqueConstraints = {
 		@UniqueConstraint(columnNames = {"child_comment_id", "member_id"})
-	})
+	},
+	indexes = {
+		@Index(name = "child_comment_likes", columnList = "child_comment_id, member_id")
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 public class ChildCommentLike extends Like {
 

--- a/backend/src/main/java/aimo/backend/domains/like/entity/ParentCommentLike.java
+++ b/backend/src/main/java/aimo/backend/domains/like/entity/ParentCommentLike.java
@@ -6,6 +6,7 @@ import aimo.backend.domains.comment.entity.ParentComment;
 import aimo.backend.domains.member.entity.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,7 +21,11 @@ import lombok.NoArgsConstructor;
 	name = "parent_comment_likes",
 	uniqueConstraints = {
 		@UniqueConstraint(columnNames = {"parent_comment_id", "member_id"})
-	})
+	},
+	indexes = {
+		@Index(name = "parent_comment_likes_idx", columnList = "parent_comment_id, member_id")
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 public class ParentCommentLike extends Like {
 

--- a/backend/src/main/java/aimo/backend/domains/like/entity/PostLike.java
+++ b/backend/src/main/java/aimo/backend/domains/like/entity/PostLike.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
@@ -19,7 +20,11 @@ import lombok.NoArgsConstructor;
 	name = "post_likes",
 	uniqueConstraints = {
 		@UniqueConstraint(columnNames = {"post_id", "member_id"})
-	})
+	},
+	indexes = {
+		@Index(name = "post_likes_idx", columnList = "post_id, member_id")
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 public class PostLike {
 

--- a/backend/src/main/java/aimo/backend/domains/member/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/aimo/backend/domains/member/dto/request/SignUpRequest.java
@@ -22,8 +22,6 @@ public record SignUpRequest(
 	@NotBlank(message = "password가 빈 문자열입니다.")
 	@Size(min = 6, message = "비밀번호는 6자 이상이어야 합니다.")
 	String password,
-	@JsonSetter(nulls = Nulls.SKIP)
-	String url,
   	@NotNull(message = "gender가 비었습니다.")
 	Gender gender,
   	@Past(message = "생년월일은 과거 날짜여야 합니다.")

--- a/backend/src/main/java/aimo/backend/domains/member/repository/MemberRepository.java
+++ b/backend/src/main/java/aimo/backend/domains/member/repository/MemberRepository.java
@@ -11,8 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByEmail(String email);
 
-	boolean existsByNickname(String nickname);
-
 	boolean existsByEmailAndProvider(String email, Provider provider);
 
 	Optional<Member> findByEmailAndProvider(String email, Provider provider);

--- a/backend/src/main/java/aimo/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/aimo/backend/domains/post/entity/Post.java
@@ -29,6 +29,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -39,8 +40,13 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "posts")
 @NoArgsConstructor(access = PROTECTED)
+@Table(name = "posts",
+	indexes = {
+		@Index(name = "posts_idx_member_id", columnList = "member_id"),
+		@Index(name = "posts_idx_post_views_count", columnList = "post_views_count"),
+	}
+)
 public class Post extends BaseEntity {
 
 	@Id

--- a/backend/src/main/java/aimo/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/aimo/backend/domains/post/repository/PostRepository.java
@@ -19,11 +19,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	Boolean existsByIdAndMember_Id(Long postId, Long memberId);
 
 	@Query("""
-    SELECT DISTINCT p
-    FROM Post p
-    LEFT JOIN ParentComment pc ON pc.post.id = p.id
-    LEFT JOIN ChildComment cc ON cc.post.id = p.id
-    WHERE pc.member.id = :memberId OR cc.member.id = :memberId
-""")
+		    SELECT DISTINCT p
+		    FROM Post p
+		    LEFT JOIN ParentComment pc ON pc.post.id = p.id
+		    LEFT JOIN ChildComment cc ON cc.post.id = p.id
+		    WHERE pc.member.id = :memberId OR cc.member.id = :memberId
+		""")
 	Page<Post> findPostsByCommentsWrittenByMember(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/backend/src/main/java/aimo/backend/domains/privatePost/entity/PrivatePost.java
+++ b/backend/src/main/java/aimo/backend/domains/privatePost/entity/PrivatePost.java
@@ -18,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
@@ -28,7 +29,11 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "private_posts")
+@Table(name = "private_posts",
+	indexes = {
+		@Index(name = "private_posts_idx_member_id", columnList = "member_id")
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 public class PrivatePost extends BaseEntity {
 

--- a/backend/src/main/java/aimo/backend/domains/privatePost/repository/PrivatePostRepository.java
+++ b/backend/src/main/java/aimo/backend/domains/privatePost/repository/PrivatePostRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import aimo.backend.domains.privatePost.entity.PrivatePost;
 
 public interface PrivatePostRepository extends JpaRepository<PrivatePost, Long> {
-	Page<PrivatePost> findByMemberId(Long memberId, Pageable pageable);
+	Page<PrivatePost> findAllByMemberId(Long memberId, Pageable pageable);
 
 	Optional<PrivatePost> findByMember_IdAndId(Long memberId, Long id);
 }

--- a/backend/src/main/java/aimo/backend/domains/privatePost/service/PrivatePostService.java
+++ b/backend/src/main/java/aimo/backend/domains/privatePost/service/PrivatePostService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import aimo.backend.common.dto.PageResponse;
 import aimo.backend.common.exception.ApiException;
 import aimo.backend.common.exception.ErrorCode;
-import aimo.backend.common.properties.AiServerProperties;
 import aimo.backend.domains.member.entity.Member;
 import aimo.backend.domains.member.model.DecreasePoint;
 import aimo.backend.domains.member.repository.MemberRepository;
@@ -38,7 +37,6 @@ public class PrivatePostService {
 
 	private final PrivatePostRepository privatePostRepository;
 	private final MemberRepository memberRepository;
-	private final AiServerProperties aiServerProperties;
 	private final MemberPointService memberPointService;
 
 	// AI로부터 받은 콜백 응답을 기존에 저장했던 PrivatePost에 업데이트
@@ -139,8 +137,9 @@ public class PrivatePostService {
 
 	// 개인글 목록 조회
 	public PageResponse<PrivatePostPreviewResponse> findPrivatePostPreviewsBy(
-		FindPrivatePostPreviewParameter parameter) {
-		Page<PrivatePostPreviewResponse> privatePosts = privatePostRepository.findByMemberId(parameter.memberId(),
+		FindPrivatePostPreviewParameter parameter
+	) {
+		Page<PrivatePostPreviewResponse> privatePosts = privatePostRepository.findAllByMemberId(parameter.memberId(),
 				parameter.pageable())
 			.map(PrivatePostPreviewResponse::from);
 


### PR DESCRIPTION
## issue
- close #100

## 구현 의도
- 데이터를 50만개를 넣고 성능 테스트를 해본 결과 성능이 크게 떨어짐을 알 수 있었다. 이를 해결해보고자 한다.

## 구현 사항
**문제상황**

- 게시글 목록 성능 최적화를 했음에도 불구하고, 데이터가 쌓일수록 성능이 크게 저하됨을  알게 됨.
- 50만 개의 데이터를 넣고 테스트해본 결과, 평균 응답 시간이 대폭 증가함.

**해결과정**

- 문제의 원인을 분석한 결과, 데이터베이스 테이블에 Index가 없어서 조회 시 전체 테이블 스캔(Full Table Scan)이 발생하는 것이 주요 원인임을 확인
- 게시글 조회 쿼리에서 자주 사용되는 조건문과 정렬 기준에 맞는 적절한 Index를 설계하고 적용

**성과**

- AWS `t2.micro` 기준 1명의 유저에 대한 응답시간이 1.8s → 0.6s로 대략 3배 정도 개선
- AWS `t2.micro` 기준 1000명의 유저에 대한 평균 응답시간이 110s → 4s로 대략 25배 개선

![image](https://github.com/user-attachments/assets/0524ecff-4a48-4633-bdca-024053495f1b)


